### PR TITLE
fix: remove connection string

### DIFF
--- a/src/internal/initialize.ts
+++ b/src/internal/initialize.ts
@@ -16,7 +16,7 @@ export const notificationApp = new ConversationBot({
   notification: {
     enabled: true,
     storage: new BlobsStorage(
-      "DefaultEndpointsProtocol=https;AccountName=diversitypulse;AccountKey=/Z3kX3U1yh6GxyRQBGLQE8KqMJv3M9nm6Cm7qcp9hi/um5EHWDgh0oC0Jz1nPDC0YZOip87Xu4qI+ASttfasGg==;EndpointSuffix=core.windows.net",
+      process.env.STORAGE_CONNECTION_STRING,
       "blobstorage"
     ),
   },


### PR DESCRIPTION
Need to replace "process.env.STORAGE_CONNECTION_STRING" with the connection string of https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/e24d88be-b95f-4815-ba25-ae48defc8da2/resourceGroups/DiversityPulse-dev-rg/providers/Microsoft.Storage/storageAccounts/diversitypulse/keys before debugging and deploying.