### PR TITLE
fix: local use local storage and others use the storage created by bicep

### DIFF
--- a/infra/azure.bicep
+++ b/infra/azure.bicep
@@ -16,6 +16,11 @@ param storageSKU string
 @maxLength(42)
 param botDisplayName string
 
+@description('Env File Name, such as dev')
+param envName string
+@description('TEAMS APP ID')
+param teamsAppId string
+
 param serverfarmsName string = resourceBaseName
 param functionAppName string = resourceBaseName
 param location string = resourceGroup().location
@@ -87,6 +92,14 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         {
           name: 'BOT_PASSWORD'
           value: botAadAppClientSecret
+        }
+        {
+          name: 'TEAMSFX_ENV'
+          value: envName
+        }
+        {
+          name: 'TEAMS_APP_ID'
+          value: teamsAppId
         }
         {
           name: 'RUNNING_ON_AZURE'

--- a/infra/azure.parameters.json
+++ b/infra/azure.parameters.json
@@ -19,6 +19,12 @@
     },
     "botDisplayName": {
       "value": "Diversity Pulse"
+    },
+    "envName": {
+      "value": "${{TEAMSFX_ENV}}"
+    },
+    "teamsAppId": {
+      "value": "${{TEAMS_APP_ID}}"
     }
   }
 }

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,6 +1,9 @@
 const config = {
   botId: process.env.BOT_ID,
   botPassword: process.env.BOT_PASSWORD,
+  storageConnectionString: process.env.WEBSITE_CONTENTAZUREFILECONNECTIONSTRING,
+  envName: process.env.TEAMSFX_ENV,
+  teamsAppId: process.env.TEAMS_APP_ID,
 };
 
 export default config;

--- a/src/internal/initialize.ts
+++ b/src/internal/initialize.ts
@@ -3,6 +3,10 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 import { BlobsStorage } from "../storage/blobsStorage";
 
+const BlobStorageName = config.storageConnectionString;
+const BlobContainerName =
+  `dni-${config.envName}-${config.teamsAppId}`.toLocaleLowerCase();
+
 // Create bot.
 export const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
@@ -15,9 +19,13 @@ export const notificationApp = new ConversationBot({
   // Enable notification
   notification: {
     enabled: true,
-    storage: new BlobsStorage(
-      process.env.STORAGE_CONNECTION_STRING,
-      "blobstorage"
-    ),
+    // The storage to store the notification data.
+    // Local storage is used if not specified.
+    storage: config.storageConnectionString
+      ? new BlobsStorage(
+          BlobStorageName, // Azure Blob Storage connection string
+          BlobContainerName // Azure Blob Storage container name
+        )
+      : undefined,
   },
 });


### PR DESCRIPTION
For local env, use the local storage.
For other env, use the storage created by the bicep. Add the TEAMSFX_ENV and TEAMS_APP_ID to the Function resource configuration.